### PR TITLE
fix(runtime): Correct NewWithFactories service creation loop

### DIFF
--- a/runtime_pkg.go
+++ b/runtime_pkg.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/wailsapp/wails/v3/pkg/application"
 )
@@ -24,11 +25,14 @@ func NewWithFactories(app *application.App, factories map[string]ServiceFactory)
 		WithWails(app),
 	}
 
-	for _, name := range []string{} {
-		factory, ok := factories[name]
-		if !ok {
-			return nil, fmt.Errorf("service %s factory not provided", name)
-		}
+	names := make([]string, 0, len(factories))
+	for name := range factories {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		factory := factories[name]
 		svc, err := factory()
 		if err != nil {
 			return nil, fmt.Errorf("failed to create service %s: %w", name, err)

--- a/runtime_pkg_test.go
+++ b/runtime_pkg_test.go
@@ -66,9 +66,31 @@ func TestNewWithFactories_Good(t *testing.T) {
 	rt, err := NewWithFactories(nil, factories)
 	assert.NoError(t, err)
 	assert.NotNil(t, rt)
-	// The production code doesn't actually use the factories, so we can't test that a service is created.
-	// We can only test that the function runs without error.
-	assert.Nil(t, rt.Core.Service("test"))
+	svc := rt.Core.Service("test")
+	assert.NotNil(t, svc)
+	mockSvc, ok := svc.(*MockService)
+	assert.True(t, ok)
+	assert.Equal(t, "test", mockSvc.Name)
+}
+
+func TestNewWithFactories_Bad(t *testing.T) {
+	factories := map[string]ServiceFactory{
+		"test": func() (any, error) {
+			return nil, assert.AnError
+		},
+	}
+	_, err := NewWithFactories(nil, factories)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+func TestNewWithFactories_Ugly(t *testing.T) {
+	factories := map[string]ServiceFactory{
+		"test": nil,
+	}
+	assert.Panics(t, func() {
+		_, _ = NewWithFactories(nil, factories)
+	})
 }
 
 func TestRuntime_Lifecycle_Good(t *testing.T) {


### PR DESCRIPTION
Previously, the `NewWithFactories` function in `runtime_pkg.go` iterated over an empty slice, which prevented any services from being created from the provided factories. This commit fixes the loop to correctly iterate over the keys of the `factories` map, ensuring that services are properly instantiated and registered.

feat(testing): Add Good, Bad, and Ugly tests for NewWithFactories

To improve test quality and ensure the reliability of the `NewWithFactories` function, this commit replaces the existing basic test with a comprehensive test suite following the Good, Bad, Ugly methodology:

- `TestNewWithFactories_Good`: Verifies the happy path, ensuring a service is created and registered successfully.
- `TestNewWithFactories_Bad`: Checks that the function correctly returns an error when a service factory fails.
- `TestNewWithFactories_Ugly`: Confirms that the function panics when a `nil` factory is provided, as this represents an unrecoverable programmer error.