### PR TITLE
fix(vm): use double-dash flags for linuxkit build command

### DIFF
--- a/pkg/build/builders/linuxkit.go
+++ b/pkg/build/builders/linuxkit.go
@@ -149,17 +149,17 @@ func (b *LinuxKitBuilder) buildLinuxKitArgs(configPath, format, outputName, outp
 	args := []string{"build"}
 
 	// Output format
-	args = append(args, "-format", format)
+	args = append(args, "--format", format)
 
 	// Output name
-	args = append(args, "-name", outputName)
+	args = append(args, "--name", outputName)
 
 	// Output directory
-	args = append(args, "-dir", outputDir)
+	args = append(args, "--dir", outputDir)
 
 	// Architecture (if not amd64)
 	if arch != "amd64" {
-		args = append(args, "-arch", arch)
+		args = append(args, "--arch", arch)
 	}
 
 	// Config file

--- a/pkg/php/container.go
+++ b/pkg/php/container.go
@@ -238,8 +238,8 @@ func BuildLinuxKit(ctx context.Context, opts LinuxKitBuildOptions) error {
 	// Build LinuxKit image
 	args := []string{
 		"build",
-		"-format", opts.Format,
-		"-name", opts.OutputPath,
+		"--format", opts.Format,
+		"--name", opts.OutputPath,
 		tempYAML,
 	}
 

--- a/pkg/release/publishers/linuxkit.go
+++ b/pkg/release/publishers/linuxkit.go
@@ -236,17 +236,17 @@ func (p *LinuxKitPublisher) buildLinuxKitArgs(configPath, format, outputName, ou
 	args := []string{"build"}
 
 	// Output format
-	args = append(args, "-format", format)
+	args = append(args, "--format", format)
 
 	// Output name
-	args = append(args, "-name", outputName)
+	args = append(args, "--name", outputName)
 
 	// Output directory
-	args = append(args, "-dir", outputDir)
+	args = append(args, "--dir", outputDir)
 
 	// Architecture (if not amd64)
 	if arch != "amd64" {
-		args = append(args, "-arch", arch)
+		args = append(args, "--arch", arch)
 	}
 
 	// Config file

--- a/pkg/release/publishers/linuxkit_test.go
+++ b/pkg/release/publishers/linuxkit_test.go
@@ -66,21 +66,21 @@ func TestLinuxKitPublisher_BuildLinuxKitArgs_Good(t *testing.T) {
 		args := p.buildLinuxKitArgs("/config/server.yml", "iso", "linuxkit-1.0.0-amd64", "/output", "amd64")
 
 		assert.Contains(t, args, "build")
-		assert.Contains(t, args, "-format")
+		assert.Contains(t, args, "--format")
 		assert.Contains(t, args, "iso")
-		assert.Contains(t, args, "-name")
+		assert.Contains(t, args, "--name")
 		assert.Contains(t, args, "linuxkit-1.0.0-amd64")
-		assert.Contains(t, args, "-dir")
+		assert.Contains(t, args, "--dir")
 		assert.Contains(t, args, "/output")
 		assert.Contains(t, args, "/config/server.yml")
-		// Should not contain -arch for amd64 (default)
-		assert.NotContains(t, args, "-arch")
+		// Should not contain --arch for amd64 (default)
+		assert.NotContains(t, args, "--arch")
 	})
 
 	t.Run("builds args with arch for arm64", func(t *testing.T) {
 		args := p.buildLinuxKitArgs("/config/server.yml", "qcow2", "linuxkit-1.0.0-arm64", "/output", "arm64")
 
-		assert.Contains(t, args, "-arch")
+		assert.Contains(t, args, "--arch")
 		assert.Contains(t, args, "arm64")
 		assert.Contains(t, args, "qcow2")
 	})
@@ -604,7 +604,7 @@ func TestLinuxKitPublisher_GetFormatExtension_AllFormats_Good(t *testing.T) {
 		{"docker", ".docker.tar"},
 		{"tar", ".tar"},
 		{"kernel+initrd", "-initrd.img"},
-		{"custom-format", ".custom-format"},
+		{"custom--format", ".custom--format"},
 	}
 
 	for _, tc := range tests {
@@ -619,30 +619,30 @@ func TestLinuxKitPublisher_BuildLinuxKitArgs_AllArchitectures_Good(t *testing.T)
 	p := NewLinuxKitPublisher()
 
 	t.Run("amd64 does not include arch flag", func(t *testing.T) {
-		args := p.buildLinuxKitArgs("/config.yml", "iso", "output-name", "/output", "amd64")
+		args := p.buildLinuxKitArgs("/config.yml", "iso", "output--name", "/output", "amd64")
 
 		assert.Contains(t, args, "build")
-		assert.Contains(t, args, "-format")
+		assert.Contains(t, args, "--format")
 		assert.Contains(t, args, "iso")
-		assert.Contains(t, args, "-name")
-		assert.Contains(t, args, "output-name")
-		assert.Contains(t, args, "-dir")
+		assert.Contains(t, args, "--name")
+		assert.Contains(t, args, "output--name")
+		assert.Contains(t, args, "--dir")
 		assert.Contains(t, args, "/output")
 		assert.Contains(t, args, "/config.yml")
-		assert.NotContains(t, args, "-arch")
+		assert.NotContains(t, args, "--arch")
 	})
 
 	t.Run("arm64 includes arch flag", func(t *testing.T) {
-		args := p.buildLinuxKitArgs("/config.yml", "qcow2", "output-name", "/output", "arm64")
+		args := p.buildLinuxKitArgs("/config.yml", "qcow2", "output--name", "/output", "arm64")
 
-		assert.Contains(t, args, "-arch")
+		assert.Contains(t, args, "--arch")
 		assert.Contains(t, args, "arm64")
 	})
 
 	t.Run("other architectures include arch flag", func(t *testing.T) {
-		args := p.buildLinuxKitArgs("/config.yml", "raw", "output-name", "/output", "riscv64")
+		args := p.buildLinuxKitArgs("/config.yml", "raw", "output--name", "/output", "riscv64")
 
-		assert.Contains(t, args, "-arch")
+		assert.Contains(t, args, "--arch")
 		assert.Contains(t, args, "riscv64")
 	})
 }


### PR DESCRIPTION
## Summary

- Updates all linuxkit command invocations to use double-dash flags
- Fixes compatibility with linuxkit v1.8.2+

## Problem

LinuxKit v1.8.2+ requires double-dash flags (`--format`, `--name`, etc.). The single-dash flags were being parsed incorrectly:

```
Error: unknown shorthand flag: 'n' in -name
```

The `-name` flag was interpreted as `-n` (shorthand) with value `ame`.

## Changes

| File | Changes |
|------|---------|
| `pkg/build/builders/linuxkit.go` | `-format` → `--format`, `-name` → `--name`, `-dir` → `--dir`, `-arch` → `--arch` |
| `pkg/php/container.go` | `-format` → `--format`, `-name` → `--name` |
| `pkg/release/publishers/linuxkit.go` | Same as above |
| `pkg/release/publishers/linuxkit_test.go` | Updated test assertions |

## Test plan

- [x] Updated tests to check for double-dash flags
- [ ] Manual test with linuxkit v1.8.2+

Fixes #50

---

🤖 Generated with [Claude Code](https://claude.ai/code)