### PR TITLE
fix(agentic): use context.TODO instead of nil Context

### DIFF
--- a/pkg/agentic/completion_test.go
+++ b/pkg/agentic/completion_test.go
@@ -1,6 +1,7 @@
 package agentic
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -153,14 +154,14 @@ func TestGenerateBranchName(t *testing.T) {
 }
 
 func TestAutoCommit_Bad_NilTask(t *testing.T) {
-	err := AutoCommit(nil, nil, ".", "test message")
+	err := AutoCommit(context.TODO(), nil, ".", "test message")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "task is required")
 }
 
 func TestAutoCommit_Bad_EmptyMessage(t *testing.T) {
 	task := &Task{ID: "123", Title: "Test"}
-	err := AutoCommit(nil, task, ".", "")
+	err := AutoCommit(context.TODO(), task, ".", "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "commit message is required")
 }
@@ -169,7 +170,7 @@ func TestSyncStatus_Bad_NilClient(t *testing.T) {
 	task := &Task{ID: "123", Title: "Test"}
 	update := TaskUpdate{Status: StatusInProgress}
 
-	err := SyncStatus(nil, nil, task, update)
+	err := SyncStatus(context.TODO(), nil, task, update)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "client is required")
 }
@@ -178,20 +179,20 @@ func TestSyncStatus_Bad_NilTask(t *testing.T) {
 	client := &Client{BaseURL: "http://test"}
 	update := TaskUpdate{Status: StatusInProgress}
 
-	err := SyncStatus(nil, client, nil, update)
+	err := SyncStatus(context.TODO(), client, nil, update)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "task is required")
 }
 
 func TestCreateBranch_Bad_NilTask(t *testing.T) {
-	branch, err := CreateBranch(nil, nil, ".")
+	branch, err := CreateBranch(context.TODO(), nil, ".")
 	assert.Error(t, err)
 	assert.Empty(t, branch)
 	assert.Contains(t, err.Error(), "task is required")
 }
 
 func TestCreatePR_Bad_NilTask(t *testing.T) {
-	url, err := CreatePR(nil, nil, ".", PROptions{})
+	url, err := CreatePR(context.TODO(), nil, ".", PROptions{})
 	assert.Error(t, err)
 	assert.Empty(t, url)
 	assert.Contains(t, err.Error(), "task is required")


### PR DESCRIPTION
## Summary

Fix staticcheck SA1012 warning by replacing nil Context parameters with `context.TODO()`.

## Changes

- Import `context` package in completion_test.go
- Replace all `nil` context arguments with `context.TODO()` in test functions:
  - `TestAutoCommit_Bad_NilTask`
  - `TestAutoCommit_Bad_EmptyMessage`
  - `TestSyncStatus_Bad_NilClient`
  - `TestSyncStatus_Bad_NilTask`
  - `TestCreateBranch_Bad_NilTask`
  - `TestCreatePR_Bad_NilTask`

## Test Plan

- [x] `task test` passes (21 passed)
- [x] `task fmt` passes
- [x] `go build ./...` passes

Closes #78

---
🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized context handling throughout the codebase by updating multiple function signatures to require context as the first parameter, enabling better resource management and cancellation support.

* **Tests**
  * Updated all corresponding test cases and mock implementations to work with the refactored function signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->