### PR TITLE
feat(dev): add confirmation prompt to apply command

### DIFF
--- a/pkg/dev/cmd_apply.go
+++ b/pkg/dev/cmd_apply.go
@@ -32,6 +32,7 @@ var (
 	applyDryRun   bool
 	applyPush     bool
 	applyContinue bool // Continue on error
+	applyYes      bool // Skip confirmation prompt
 )
 
 // AddApplyCommand adds the 'apply' command to dev.
@@ -54,6 +55,7 @@ func AddApplyCommand(parent *cli.Command) {
 	applyCmd.Flags().BoolVar(&applyDryRun, "dry-run", false, i18n.T("cmd.dev.apply.flag.dry_run"))
 	applyCmd.Flags().BoolVar(&applyPush, "push", false, i18n.T("cmd.dev.apply.flag.push"))
 	applyCmd.Flags().BoolVar(&applyContinue, "continue", false, i18n.T("cmd.dev.apply.flag.continue"))
+	applyCmd.Flags().BoolVarP(&applyYes, "yes", "y", false, i18n.T("cmd.dev.apply.flag.yes"))
 
 	parent.AddCommand(applyCmd)
 }
@@ -100,6 +102,18 @@ func runApply() error {
 		cli.Print("%s\n", warningStyle.Render(i18n.T("cmd.dev.apply.dry_run_mode")))
 	}
 	cli.Blank()
+
+	// Require confirmation unless --yes or --dry-run
+	if !applyYes && !applyDryRun {
+		cli.Print("%s\n", warningStyle.Render(i18n.T("cmd.dev.apply.warning")))
+		cli.Blank()
+
+		if !cli.Confirm(i18n.T("cmd.dev.apply.confirm"), cli.Required()) {
+			cli.Print("%s\n", dimStyle.Render(i18n.T("cmd.dev.apply.cancelled")))
+			return nil
+		}
+		cli.Blank()
+	}
 
 	var succeeded, skipped, failed int
 


### PR DESCRIPTION
## Summary

Add safety confirmation prompt to `core dev apply` before executing shell commands. This prevents accidental execution of destructive commands pasted from untrusted sources or generated by AI agents.

## Changes

- Add `--yes`/`-y` flag to skip confirmation prompt
- Show warning and require explicit "y" confirmation before execution
- Allow `--dry-run` to bypass confirmation (no actual execution)
- Use existing `cli.Confirm` with `Required()` for mandatory response

## Usage

```bash
# Prompts for confirmation
core dev apply --command="rm -rf ."

# Skips confirmation (for scripts/automation)
core dev apply --command="..." --yes

# No execution, no prompt needed
core dev apply --command="..." --dry-run
```

## Test Plan

- [x] `task test` passes (22 passed)
- [x] `task fmt` passes
- [x] `go build ./...` passes
- [ ] Manual testing of confirmation flow

Closes #81

---
🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Commands now require explicit user confirmation before execution, displaying a warning and prompt. Bypass confirmation with the `--yes` or `-y` flag to proceed directly without interruption.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->