### PR TITLE
docs(process): add docstrings to Logger interface methods

### DIFF
--- a/pkg/process/exec/logger.go
+++ b/pkg/process/exec/logger.go
@@ -3,14 +3,19 @@ package exec
 // Logger interface for command execution logging.
 // Compatible with pkg/log.Logger and other structured loggers.
 type Logger interface {
+	// Debug logs a debug-level message with optional key-value pairs.
 	Debug(msg string, keyvals ...any)
+	// Error logs an error-level message with optional key-value pairs.
 	Error(msg string, keyvals ...any)
 }
 
 // NopLogger is a no-op logger that discards all messages.
 type NopLogger struct{}
 
+// Debug discards the message (no-op implementation).
 func (NopLogger) Debug(string, ...any) {}
+
+// Error discards the message (no-op implementation).
 func (NopLogger) Error(string, ...any) {}
 
 var defaultLogger Logger = NopLogger{}


### PR DESCRIPTION
## Summary

Add missing docstrings to Logger interface methods and NopLogger implementation to satisfy the 80% docstring coverage threshold.

## Changes

- Add docstring to `Logger.Debug` method
- Add docstring to `Logger.Error` method  
- Add docstring to `NopLogger.Debug` method
- Add docstring to `NopLogger.Error` method

## Test Plan

- [x] `core qa docblock ./...` passes (100% coverage)
- [x] `task test` passes
- [x] `task fmt` passes

---
🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for internal logging utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->