### PR TITLE
fix(container): prevent data race in State.Get and State.All

### DIFF
--- a/pkg/container/state.go
+++ b/pkg/container/state.go
@@ -99,13 +99,19 @@ func (s *State) Add(c *Container) error {
 	return s.SaveState()
 }
 
-// Get retrieves a container by ID.
+// Get retrieves a copy of a container by ID.
+// Returns a copy to prevent data races when the container is modified.
 func (s *State) Get(id string) (*Container, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	c, ok := s.Containers[id]
-	return c, ok
+	if !ok {
+		return nil, false
+	}
+	// Return a copy to prevent data races
+	copy := *c
+	return &copy, true
 }
 
 // Update updates a container in the state and persists it.
@@ -126,14 +132,16 @@ func (s *State) Remove(id string) error {
 	return s.SaveState()
 }
 
-// All returns all containers in the state.
+// All returns copies of all containers in the state.
+// Returns copies to prevent data races when containers are modified.
 func (s *State) All() []*Container {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	containers := make([]*Container, 0, len(s.Containers))
 	for _, c := range s.Containers {
-		containers = append(containers, c)
+		copy := *c
+		containers = append(containers, &copy)
 	}
 	return containers
 }


### PR DESCRIPTION
## Summary
Fix data race detected between `waitForExit` and `Stop` functions in LinuxKit container manager.

## Problem
`State.Get` was returning a pointer to the container stored in the map. When both `waitForExit` (line 223) and `Stop` (line 238) called `Get`, they received the same pointer and could read/write `Status` concurrently.

## Solution
Return copies of Container structs instead of pointers to the map entries. This ensures each caller has its own copy and modifications don't race.

## Issues
Fixes #76

## Test plan
- [x] All tests pass with `-race` flag
- [x] No data race detected

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data consistency and reliability in container state management by ensuring returned containers are independent copies, preventing potential data inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->