### PR TITLE
feat(agentic): migrate filesystem operations to io.Local abstraction

### DIFF
--- a/pkg/agentic/config.go
+++ b/pkg/agentic/config.go
@@ -1,12 +1,12 @@
 package agentic
 
 import (
-	"bufio"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/host-uk/core/pkg/errors"
+	"github.com/host-uk/core/pkg/io"
 	"gopkg.in/yaml.v3"
 )
 
@@ -95,15 +95,13 @@ func LoadConfig(dir string) (*Config, error) {
 
 // loadEnvFile reads a .env file and extracts agentic configuration.
 func loadEnvFile(path string, cfg *Config) error {
-	file, err := os.Open(path)
+	content, err := io.Local.Read(path)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
 
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
 
 		// Skip empty lines and comments
 		if line == "" || strings.HasPrefix(line, "#") {
@@ -134,17 +132,17 @@ func loadEnvFile(path string, cfg *Config) error {
 		}
 	}
 
-	return scanner.Err()
+	return nil
 }
 
 // loadYAMLConfig reads configuration from a YAML file.
 func loadYAMLConfig(path string, cfg *Config) error {
-	data, err := os.ReadFile(path)
+	content, err := io.Local.Read(path)
 	if err != nil {
 		return err
 	}
 
-	return yaml.Unmarshal(data, cfg)
+	return yaml.Unmarshal([]byte(content), cfg)
 }
 
 // applyEnvOverrides applies environment variable overrides to the config.
@@ -171,7 +169,7 @@ func SaveConfig(cfg *Config) error {
 	}
 
 	configDir := filepath.Join(homeDir, ".core")
-	if err := os.MkdirAll(configDir, 0755); err != nil {
+	if err := io.Local.EnsureDir(configDir); err != nil {
 		return errors.E("agentic.SaveConfig", "failed to create config directory", err)
 	}
 
@@ -182,7 +180,7 @@ func SaveConfig(cfg *Config) error {
 		return errors.E("agentic.SaveConfig", "failed to marshal config", err)
 	}
 
-	if err := os.WriteFile(configPath, data, 0600); err != nil {
+	if err := io.Local.Write(configPath, string(data)); err != nil {
 		return errors.E("agentic.SaveConfig", "failed to write config file", err)
 	}
 

--- a/pkg/agentic/context.go
+++ b/pkg/agentic/context.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/host-uk/core/pkg/errors"
+	"github.com/host-uk/core/pkg/io"
 )
 
 // FileContent represents the content of a file for AI context.
@@ -96,7 +97,7 @@ func GatherRelatedFiles(task *Task, dir string) ([]FileContent, error) {
 	for _, relPath := range task.Files {
 		fullPath := filepath.Join(dir, relPath)
 
-		content, err := os.ReadFile(fullPath)
+		content, err := io.Local.Read(fullPath)
 		if err != nil {
 			// Skip files that don't exist
 			continue
@@ -104,7 +105,7 @@ func GatherRelatedFiles(task *Task, dir string) ([]FileContent, error) {
 
 		files = append(files, FileContent{
 			Path:     relPath,
-			Content:  string(content),
+			Content:  content,
 			Language: detectLanguage(relPath),
 		})
 	}
@@ -154,20 +155,19 @@ func findRelatedCode(task *Task, dir string) ([]FileContent, error) {
 			}
 
 			fullPath := filepath.Join(dir, line)
-			content, err := os.ReadFile(fullPath)
+			content, err := io.Local.Read(fullPath)
 			if err != nil {
 				continue
 			}
 
 			// Truncate large files
-			contentStr := string(content)
-			if len(contentStr) > 5000 {
-				contentStr = contentStr[:5000] + "\n... (truncated)"
+			if len(content) > 5000 {
+				content = content[:5000] + "\n... (truncated)"
 			}
 
 			files = append(files, FileContent{
 				Path:     line,
-				Content:  contentStr,
+				Content:  content,
 				Language: detectLanguage(line),
 			})
 		}


### PR DESCRIPTION
## Summary
Migrate pkg/agentic to use io.Local abstraction instead of direct os package calls.

**config.go:**
- os.Open + bufio.Scanner → io.Local.Read + strings.Split
- os.ReadFile → io.Local.Read
- os.MkdirAll → io.Local.EnsureDir
- os.WriteFile → io.Local.Write

**context.go:**
- os.ReadFile → io.Local.Read

Part of #101 (io.Medium migration tracking issue)

## Test plan
- [x] Build succeeds with `go build ./pkg/agentic/...`
- [x] All agentic tests pass
- [ ] CI passes

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal file input/output operations through a unified abstraction layer. Enhanced consistency across configuration loading and file content processing operations. Improved error handling patterns for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->