### PR TITLE
feat(build): migrate filesystem operations to io.Local abstraction

### DIFF
--- a/pkg/build/checksum.go
+++ b/pkg/build/checksum.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	coreio "github.com/host-uk/core/pkg/io"
 )
 
 // Checksum computes SHA256 for an artifact and returns the artifact with the Checksum field filled.
@@ -89,12 +91,12 @@ func WriteChecksumFile(artifacts []Artifact, path string) error {
 
 	// Ensure directory exists
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := coreio.Local.EnsureDir(dir); err != nil {
 		return fmt.Errorf("build.WriteChecksumFile: failed to create directory: %w", err)
 	}
 
 	// Write the file
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := coreio.Local.Write(path, content); err != nil {
 		return fmt.Errorf("build.WriteChecksumFile: failed to write file: %w", err)
 	}
 

--- a/pkg/build/config.go
+++ b/pkg/build/config.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/host-uk/core/pkg/build/signing"
+	"github.com/host-uk/core/pkg/io"
 	"gopkg.in/yaml.v3"
 )
 
@@ -71,7 +72,13 @@ type TargetConfig struct {
 func LoadConfig(dir string) (*BuildConfig, error) {
 	configPath := filepath.Join(dir, ConfigDir, ConfigFileName)
 
-	data, err := os.ReadFile(configPath)
+	// Convert to absolute path for io.Local
+	absPath, err := filepath.Abs(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("build.LoadConfig: failed to resolve path: %w", err)
+	}
+
+	content, err := io.Local.Read(absPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return DefaultConfig(), nil
@@ -80,7 +87,7 @@ func LoadConfig(dir string) (*BuildConfig, error) {
 	}
 
 	var cfg BuildConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err := yaml.Unmarshal([]byte(content), &cfg); err != nil {
 		return nil, fmt.Errorf("build.LoadConfig: failed to parse config file: %w", err)
 	}
 

--- a/pkg/build/discovery.go
+++ b/pkg/build/discovery.go
@@ -1,9 +1,10 @@
 package build
 
 import (
-	"os"
 	"path/filepath"
 	"slices"
+
+	"github.com/host-uk/core/pkg/io"
 )
 
 // Marker files for project type detection.
@@ -84,9 +85,9 @@ func IsPHPProject(dir string) bool {
 
 // fileExists checks if a file exists and is not a directory.
 func fileExists(path string) bool {
-	info, err := os.Stat(path)
+	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return false
 	}
-	return !info.IsDir()
+	return io.Local.IsFile(absPath)
 }


### PR DESCRIPTION
## Summary
Migrate pkg/build to use io.Local abstraction where possible.

**config.go:**
- os.ReadFile → io.Local.Read (with filepath.Abs for relative path support)

**checksum.go:**
- os.MkdirAll → io.Local.EnsureDir
- os.WriteFile → io.Local.Write

**discovery.go:**
- os.Stat → io.Local.IsFile (with filepath.Abs for relative path support)

Note: Some operations like `os.Open` for file hashing remain unchanged as they require io.Reader interfaces that Medium doesn't provide.

Part of #101 (io.Medium migration tracking issue)

## Test plan
- [x] Build succeeds with `go build ./pkg/build/...`
- [x] All build tests pass
- [ ] CI passes

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to file I/O operations for better maintainability and consistency across the build system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->