### PR TITLE
ci(workflows): use host-uk/build@dev for releases

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,10 @@
 # CodeRabbit Configuration
 # Inherits from: https://github.com/host-uk/coderabbit/.coderabbit.yaml
+# Manual trigger only: @coderabbitai review
 
 reviews:
+  auto_review:
+    enabled: false
   review_status: false
   
   path_instructions:

--- a/.github/workflows/agent-verify.yml
+++ b/.github/workflows/agent-verify.yml
@@ -1,4 +1,5 @@
-name: Agent Verification Workflow
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issues
+name: "Agent Verification: Issue Labeled"
 
 on:
   issues:

--- a/.github/workflows/alpha-release-manual.yml
+++ b/.github/workflows/alpha-release-manual.yml
@@ -1,0 +1,92 @@
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
+name: "Alpha Release: Manual"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+env:
+  NEXT_VERSION: "0.0.4"
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux/amd64
+          - os: ubuntu-latest
+            platform: linux/arm64
+          - os: macos-latest
+            platform: darwin/universal
+          - os: windows-latest
+            platform: windows/amd64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build
+        uses: host-uk/build@v3
+        with:
+          build-name: core
+          build-platform: ${{ matrix.platform }}
+          build: true
+          package: true
+          sign: false
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Prepare release files
+        run: |
+          mkdir -p release
+          cp dist/* release/ 2>/dev/null || true
+          ls -la release/
+
+      - name: Create alpha release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="v${{ env.NEXT_VERSION }}-alpha.${{ github.run_number }}"
+
+          gh release create "$VERSION" \
+            --title "Alpha: $VERSION" \
+            --notes "Canary build from dev branch.
+
+          **Version:** $VERSION
+          **Commit:** ${{ github.sha }}
+          **Built:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')
+          **Run:** ${{ github.run_id }}
+
+          ## Channel: Alpha (Canary)
+
+          This is an automated pre-release for early testing.
+
+          - Systems and early adopters can test breaking changes
+          - Quality scoring determines promotion to beta
+          - Use stable releases for production
+
+          ## Installation
+
+          \`\`\`bash
+          # macOS/Linux
+          curl -fsSL https://github.com/host-uk/core/releases/download/$VERSION/core-linux-amd64 -o core
+          chmod +x core && sudo mv core /usr/local/bin/
+          \`\`\`
+          " \
+            --prerelease \
+            --target dev \
+            release/*

--- a/.github/workflows/alpha-release-push.yml
+++ b/.github/workflows/alpha-release-push.yml
@@ -1,13 +1,17 @@
 # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push
-name: "Release: Tag Push"
+name: "Alpha Release: Push"
 
 on:
   push:
-    tags:
-      - 'v*.*.*'
+    branches: [dev]
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
+
+env:
+  NEXT_VERSION: "0.0.4"
 
 jobs:
   build:
@@ -53,12 +57,37 @@ jobs:
           cp dist/* release/ 2>/dev/null || true
           ls -la release/
 
-      - name: Create release
+      - name: Create alpha release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ github.ref_name }}
         run: |
-          gh release create "$TAG_NAME" \
-            --title "Release $TAG_NAME" \
-            --generate-notes \
+          VERSION="v${{ env.NEXT_VERSION }}-alpha.${{ github.run_number }}"
+
+          gh release create "$VERSION" \
+            --title "Alpha: $VERSION" \
+            --notes "Canary build from dev branch.
+
+          **Version:** $VERSION
+          **Commit:** ${{ github.sha }}
+          **Built:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')
+          **Run:** ${{ github.run_id }}
+
+          ## Channel: Alpha (Canary)
+
+          This is an automated pre-release for early testing.
+
+          - Systems and early adopters can test breaking changes
+          - Quality scoring determines promotion to beta
+          - Use stable releases for production
+
+          ## Installation
+
+          \`\`\`bash
+          # macOS/Linux
+          curl -fsSL https://github.com/host-uk/core/releases/download/$VERSION/core-linux-amd64 -o core
+          chmod +x core && sudo mv core /usr/local/bin/
+          \`\`\`
+          " \
+            --prerelease \
+            --target dev \
             release/*

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -1,4 +1,4 @@
-name: Dev Release
+name: Alpha Release
 
 on:
   push:
@@ -7,9 +7,12 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 env:
-  CORE_VERSION: dev
+  # Next version - update when releasing
+  NEXT_VERSION: "0.0.4"
 
 jobs:
   build:
@@ -55,34 +58,37 @@ jobs:
           cp dist/* release/ 2>/dev/null || true
           ls -la release/
 
-      - name: Delete existing dev release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release delete dev -y || true
-
-      - name: Delete existing dev tag
-        run: git push origin :refs/tags/dev || true
-
-      - name: Create dev release
+      - name: Create alpha release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create dev \
-            --title "Development Build" \
-            --notes "Latest development build from the dev branch.
+          VERSION="v${{ env.NEXT_VERSION }}-alpha.${{ github.run_number }}"
 
+          gh release create "$VERSION" \
+            --title "Alpha: $VERSION" \
+            --notes "Canary build from dev branch.
+
+          **Version:** $VERSION
           **Commit:** ${{ github.sha }}
           **Built:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')
+          **Run:** ${{ github.run_id }}
+
+          ## Channel: Alpha (Canary)
+
+          This is an automated pre-release for early testing.
+
+          - Systems and early adopters can test breaking changes
+          - Quality scoring determines promotion to beta
+          - Use stable releases for production
 
           ## Installation
 
           \`\`\`bash
           # macOS/Linux
-          curl -fsSL https://github.com/host-uk/core/releases/download/dev/core-linux-amd64 -o core
+          curl -fsSL https://github.com/host-uk/core/releases/download/$VERSION/core-linux-amd64 -o core
           chmod +x core && sudo mv core /usr/local/bin/
           \`\`\`
-
-          This is a pre-release for testing. Use tagged releases for production." \
+          " \
             --prerelease \
             --target dev \
             release/*

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -29,7 +29,7 @@ jobs:
             platform: windows/amd64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build
         uses: host-uk/build@v3
@@ -44,10 +44,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build
-        uses: host-uk/build@dev
+        uses: host-uk/build@v3
         with:
           build-name: core
           build-platform: ${{ matrix.platform }}

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,4 +1,5 @@
-name: Auto Label Issues
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issues
+name: "Auto Label: Issue Created/Edited"
 
 on:
   issues:

--- a/.github/workflows/auto-project.yml
+++ b/.github/workflows/auto-project.yml
@@ -1,4 +1,5 @@
-name: Auto-add to Project
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issues
+name: "Auto Project: Issue Created/Labeled"
 
 on:
   issues:

--- a/.github/workflows/ci-manual.yml
+++ b/.github/workflows/ci-manual.yml
@@ -1,10 +1,7 @@
-name: CI
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
+name: "CI: Manual"
 
 on:
-  push:
-    branches: [dev, main]
-  pull_request:
-    branches: [dev, main]
   workflow_dispatch:
 
 env:
@@ -24,9 +21,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          # Try 4.1 first (Ubuntu 22.04+), fall back to 4.0 (Ubuntu 20.04)
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev || \
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
 
       - name: Build core CLI
         run: |

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -1,11 +1,9 @@
-name: CI
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+name: "CI: Pull Request"
 
 on:
-  push:
-    branches: [dev, main]
   pull_request:
     branches: [dev, main]
-  workflow_dispatch:
 
 env:
   CORE_VERSION: dev
@@ -24,9 +22,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          # Try 4.1 first (Ubuntu 22.04+), fall back to 4.0 (Ubuntu 20.04)
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev || \
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
 
       - name: Build core CLI
         run: |

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -1,11 +1,9 @@
-name: CI
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push
+name: "CI: Push"
 
 on:
   push:
     branches: [dev, main]
-  pull_request:
-    branches: [dev, main]
-  workflow_dispatch:
 
 env:
   CORE_VERSION: dev
@@ -24,9 +22,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          # Try 4.1 first (Ubuntu 22.04+), fall back to 4.0 (Ubuntu 20.04)
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev || \
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
 
       - name: Build core CLI
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   qa:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
+          # Try 4.1 first (Ubuntu 22.04+), fall back to 4.0 (Ubuntu 20.04)
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev || \
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
 
       - name: Build core CLI
         run: |

--- a/.github/workflows/codeql-pull-request.yml
+++ b/.github/workflows/codeql-pull-request.yml
@@ -1,0 +1,32 @@
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+name: "CodeQL: Pull Request"
+
+on:
+  pull_request:
+    branches: [dev, main]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: go
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:go"

--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -1,0 +1,32 @@
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push
+name: "CodeQL: Push"
+
+on:
+  push:
+    branches: [dev, main]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: go
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:go"

--- a/.github/workflows/codeql-schedule.yml
+++ b/.github/workflows/codeql-schedule.yml
@@ -1,0 +1,32 @@
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+name: "CodeQL: Schedule"
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: go
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:go"

--- a/.github/workflows/codescan-pull-request.yml
+++ b/.github/workflows/codescan-pull-request.yml
@@ -1,0 +1,30 @@
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+name: "Code Scanning: Pull Request"
+
+on:
+  pull_request:
+    branches: ["dev"]
+
+jobs:
+  CodeQL:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+
+      - name: "Initialize CodeQL"
+        uses: github/codeql-action/init@v4
+        with:
+          languages: go,javascript,typescript
+
+      - name: "Autobuild"
+        uses: github/codeql-action/autobuild@v4
+
+      - name: "Perform CodeQL Analysis"
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codescan-push.yml
+++ b/.github/workflows/codescan-push.yml
@@ -1,0 +1,30 @@
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push
+name: "Code Scanning: Push"
+
+on:
+  push:
+    branches: ["dev"]
+
+jobs:
+  CodeQL:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+
+      - name: "Initialize CodeQL"
+        uses: github/codeql-action/init@v4
+        with:
+          languages: go,javascript,typescript
+
+      - name: "Autobuild"
+        uses: github/codeql-action/autobuild@v4
+
+      - name: "Perform CodeQL Analysis"
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codescan-schedule.yml
+++ b/.github/workflows/codescan-schedule.yml
@@ -1,0 +1,30 @@
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+name: "Code Scanning: Schedule"
+
+on:
+  schedule:
+    - cron: "0 2 * * 1-5"
+
+jobs:
+  CodeQL:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+
+      - name: "Initialize CodeQL"
+        uses: github/codeql-action/init@v4
+        with:
+          languages: go,javascript,typescript
+
+      - name: "Autobuild"
+        uses: github/codeql-action/autobuild@v4
+
+      - name: "Perform CodeQL Analysis"
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/coverage-manual.yml
+++ b/.github/workflows/coverage-manual.yml
@@ -1,17 +1,14 @@
-name: CI
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
+name: "Coverage: Manual"
 
 on:
-  push:
-    branches: [dev, main]
-  pull_request:
-    branches: [dev, main]
   workflow_dispatch:
 
 env:
   CORE_VERSION: dev
 
 jobs:
-  qa:
+  coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -24,9 +21,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          # Try 4.1 first (Ubuntu 22.04+), fall back to 4.0 (Ubuntu 20.04)
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev || \
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
 
       - name: Build core CLI
         run: |
@@ -36,11 +31,16 @@ jobs:
       - name: Generate code
         run: go generate ./internal/cmd/updater/...
 
-      - name: Run QA
-        # Skip lint until golangci-lint supports Go 1.25
-        run: core go qa --skip=lint
+      - name: Run coverage
+        run: core go cov
 
-      - name: Verify build
-        run: |
-          core build --targets=linux/amd64 --ci
-          dist/linux_amd64/core --version
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-report
+          path: coverage.txt

--- a/.github/workflows/coverage-pull-request.yml
+++ b/.github/workflows/coverage-pull-request.yml
@@ -1,17 +1,15 @@
-name: CI
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+name: "Coverage: Pull Request"
 
 on:
-  push:
-    branches: [dev, main]
   pull_request:
     branches: [dev, main]
-  workflow_dispatch:
 
 env:
   CORE_VERSION: dev
 
 jobs:
-  qa:
+  coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -24,9 +22,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          # Try 4.1 first (Ubuntu 22.04+), fall back to 4.0 (Ubuntu 20.04)
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev || \
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
 
       - name: Build core CLI
         run: |
@@ -36,11 +32,16 @@ jobs:
       - name: Generate code
         run: go generate ./internal/cmd/updater/...
 
-      - name: Run QA
-        # Skip lint until golangci-lint supports Go 1.25
-        run: core go qa --skip=lint
+      - name: Run coverage
+        run: core go cov
 
-      - name: Verify build
-        run: |
-          core build --targets=linux/amd64 --ci
-          dist/linux_amd64/core --version
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-report
+          path: coverage.txt

--- a/.github/workflows/coverage-push.yml
+++ b/.github/workflows/coverage-push.yml
@@ -1,17 +1,15 @@
-name: CI
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push
+name: "Coverage: Push"
 
 on:
   push:
     branches: [dev, main]
-  pull_request:
-    branches: [dev, main]
-  workflow_dispatch:
 
 env:
   CORE_VERSION: dev
 
 jobs:
-  qa:
+  coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -24,9 +22,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          # Try 4.1 first (Ubuntu 22.04+), fall back to 4.0 (Ubuntu 20.04)
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev || \
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
 
       - name: Build core CLI
         run: |
@@ -36,11 +32,16 @@ jobs:
       - name: Generate code
         run: go generate ./internal/cmd/updater/...
 
-      - name: Run QA
-        # Skip lint until golangci-lint supports Go 1.25
-        run: core go qa --skip=lint
+      - name: Run coverage
+        run: core go cov
 
-      - name: Verify build
-        run: |
-          core build --targets=linux/amd64 --ci
-          dist/linux_amd64/core --version
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-report
+          path: coverage.txt

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
+          # Try 4.1 first (Ubuntu 22.04+), fall back to 4.0 (Ubuntu 20.04)
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev || \
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
 
       - name: Build core CLI
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-report
           path: coverage.txt

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   coverage:
-    runs-on: [self-hosted, Linux]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/pr-build-manual.yml
+++ b/.github/workflows/pr-build-manual.yml
@@ -1,8 +1,7 @@
-name: PR Build
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
+name: "PR Build: Manual"
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -15,23 +14,18 @@ permissions:
   pull-requests: read
 
 env:
-  # Next version - update when releasing
   NEXT_VERSION: "0.0.4"
 
 jobs:
   build:
-    # Only build if PR is from the same repo (not forks) or manually triggered
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         include:
           - os: ubuntu-latest
             platform: linux/amd64
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Build
         uses: host-uk/build@v3
@@ -46,9 +40,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      # Safe: PR number is numeric, not user-controlled string
-      PR_NUM: ${{ github.event.pull_request.number || inputs.pr_number }}
-      PR_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      PR_NUM: ${{ inputs.pr_number }}
+      PR_SHA: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v6
 
@@ -68,7 +61,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Use dots for build metadata (semver v1 compatible)
           TAG="v${{ env.NEXT_VERSION }}.pr.${PR_NUM}.bid.${{ github.run_id }}"
 
           # Delete existing draft for this PR if it exists

--- a/.github/workflows/pr-build-pull-request.yml
+++ b/.github/workflows/pr-build-pull-request.yml
@@ -1,37 +1,31 @@
-name: PR Build
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+name: "PR Build: Pull Request"
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'PR number to build'
-        required: true
-        type: number
 
 permissions:
   contents: write
   pull-requests: read
 
 env:
-  # Next version - update when releasing
   NEXT_VERSION: "0.0.4"
 
 jobs:
   build:
-    # Only build if PR is from the same repo (not forks) or manually triggered
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
+    # Only build if PR is from the same repo (not forks)
+    if: github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       matrix:
         include:
           - os: ubuntu-latest
             platform: linux/amd64
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Build
         uses: host-uk/build@v3
@@ -46,9 +40,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      # Safe: PR number is numeric, not user-controlled string
-      PR_NUM: ${{ github.event.pull_request.number || inputs.pr_number }}
-      PR_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      PR_NUM: ${{ github.event.pull_request.number }}
+      PR_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
       - uses: actions/checkout@v6
 
@@ -68,7 +61,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Use dots for build metadata (semver v1 compatible)
           TAG="v${{ env.NEXT_VERSION }}.pr.${PR_NUM}.bid.${{ github.run_id }}"
 
           # Delete existing draft for this PR if it exists

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -27,7 +27,7 @@ jobs:
         include:
           - os: ubuntu-latest
             platform: linux/amd64
-    runs-on: ${{ matrix.os }}
+    runs-on: [self-hosted, Linux]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -44,7 +44,7 @@ jobs:
 
   draft-release:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux]
     env:
       # Safe: PR number is numeric, not user-controlled string
       PR_NUM: ${{ github.event.pull_request.number || inputs.pr_number }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,100 @@
+name: PR Build
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to build'
+        required: true
+        type: number
+
+permissions:
+  contents: write
+  pull-requests: read
+
+env:
+  # Next version - update when releasing
+  NEXT_VERSION: "0.0.4"
+
+jobs:
+  build:
+    # Only build if PR is from the same repo (not forks) or manually triggered
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux/amd64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Build
+        uses: host-uk/build@dev
+        with:
+          build-name: core
+          build-platform: ${{ matrix.platform }}
+          build: true
+          package: true
+          sign: false
+
+  draft-release:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      # Safe: PR number is numeric, not user-controlled string
+      PR_NUM: ${{ github.event.pull_request.number || inputs.pr_number }}
+      PR_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Prepare release files
+        run: |
+          mkdir -p release
+          cp dist/* release/ 2>/dev/null || true
+          ls -la release/
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Build metadata uses + which is valid semver but GitHub tags encode it
+          VERSION="v${{ env.NEXT_VERSION }}+pr.${PR_NUM}.bid.${{ github.run_id }}"
+          # GitHub tags can't have + so we use a different format for the tag
+          TAG="v${{ env.NEXT_VERSION }}-pr.${PR_NUM}.bid.${{ github.run_id }}"
+
+          # Delete existing draft for this PR if it exists
+          gh release delete "$TAG" -y 2>/dev/null || true
+          git push origin ":refs/tags/$TAG" 2>/dev/null || true
+
+          gh release create "$TAG" \
+            --title "Draft: PR #${PR_NUM}" \
+            --notes "Draft build for PR #${PR_NUM}.
+
+          **Version:** $VERSION
+          **Tag:** $TAG
+          **PR:** #${PR_NUM}
+          **Commit:** ${PR_SHA}
+          **Built:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')
+          **Run:** ${{ github.run_id }}
+
+          ## Channel: Draft
+
+          This is a draft build for testing PR changes before merge.
+          Not intended for production use.
+
+          Build artifacts available for download and testing.
+          " \
+            --draft \
+            --prerelease \
+            release/*

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -34,7 +34,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Build
-        uses: host-uk/build@dev
+        uses: host-uk/build@v3
         with:
           build-name: core
           build-platform: ${{ matrix.platform }}
@@ -68,10 +68,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Build metadata uses + which is valid semver but GitHub tags encode it
-          VERSION="v${{ env.NEXT_VERSION }}+pr.${PR_NUM}.bid.${{ github.run_id }}"
-          # GitHub tags can't have + so we use a different format for the tag
-          TAG="v${{ env.NEXT_VERSION }}-pr.${PR_NUM}.bid.${{ github.run_id }}"
+          # Use dots for build metadata (semver v1 compatible)
+          TAG="v${{ env.NEXT_VERSION }}.pr.${PR_NUM}.bid.${{ github.run_id }}"
 
           # Delete existing draft for this PR if it exists
           gh release delete "$TAG" -y 2>/dev/null || true
@@ -81,8 +79,7 @@ jobs:
             --title "Draft: PR #${PR_NUM}" \
             --notes "Draft build for PR #${PR_NUM}.
 
-          **Version:** $VERSION
-          **Tag:** $TAG
+          **Version:** $TAG
           **PR:** #${PR_NUM}
           **Commit:** ${PR_SHA}
           **Built:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -29,7 +29,7 @@ jobs:
             platform: linux/amd64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -50,10 +50,10 @@ jobs:
       PR_NUM: ${{ github.event.pull_request.number || inputs.pr_number }}
       PR_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,74 +14,31 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            goos: linux
-            goarch: amd64
-            ext: ""
+            platform: linux/amd64
           - os: ubuntu-latest
-            goos: linux
-            goarch: arm64
-            ext: ""
+            platform: linux/arm64
           - os: macos-latest
-            goos: darwin
-            goarch: amd64
-            ext: ""
-          - os: macos-latest
-            goos: darwin
-            goarch: arm64
-            ext: ""
+            platform: darwin/universal
           - os: windows-latest
-            goos: windows
-            goarch: amd64
-            ext: ".exe"
+            platform: windows/amd64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Setup Go
-        uses: actions/setup-go@v6
+      - name: Build
+        uses: host-uk/build@v3
         with:
-          go-version: '1.23'
-          cache: true
-
-      - name: Build CLI
-        shell: bash
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: "0"
-        run: |
-          mkdir -p dist
-          go build -ldflags="-s -w -X main.Version=${{ github.ref_name }}" \
-            -o dist/core${{ matrix.ext }} \
-            .
-
-      - name: Create archive (Unix)
-        if: matrix.goos != 'windows'
-        shell: bash
-        run: |
-          cd dist
-          tar -czvf core-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz core
-          rm core
-
-      - name: Create archive (Windows)
-        if: matrix.goos == 'windows'
-        shell: pwsh
-        run: |
-          cd dist
-          Compress-Archive -Path core.exe -DestinationPath core-${{ matrix.goos }}-${{ matrix.goarch }}.zip
-          Remove-Item core.exe
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: core-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: dist/core-*
+          build-name: core
+          build-platform: ${{ matrix.platform }}
+          build: true
+          package: true
+          sign: false
 
   release:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download artifacts
         uses: actions/download-artifact@v7
@@ -98,8 +55,9 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          gh release create ${{ github.ref_name }} \
-            --title "Release ${{ github.ref_name }}" \
+          gh release create "$TAG_NAME" \
+            --title "Release $TAG_NAME" \
             --generate-notes \
             release/*

--- a/ISSUES_TRIAGE.md
+++ b/ISSUES_TRIAGE.md
@@ -1,0 +1,166 @@
+# Issues Triage
+
+Generated: 2026-02-02
+
+## Summary
+
+- **Total Open Issues**: 46
+- **High Priority**: 6
+- **Audit Meta-Issues**: 13 (for Jules AI)
+- **Audit Derived Issues**: 20 (created from audits)
+
+---
+
+## High Priority Issues
+
+| # | Title | Labels |
+|---|-------|--------|
+| 183 | audit: OWASP Top 10 security review | priority:high, jules |
+| 189 | audit: Test coverage and quality | priority:high, jules |
+| 191 | audit: API design and consistency | priority:high, jules |
+| 218 | Increase test coverage for low-coverage packages | priority:high, testing |
+| 219 | Add tests for edge cases, error paths, integration | priority:high, testing |
+| 168 | feat(crypt): Implement standalone pkg/crypt | priority:high, enhancement |
+
+---
+
+## Audit Meta-Issues (For Jules AI)
+
+These are high-level audit tasks that spawn sub-issues:
+
+| # | Title | Complexity |
+|---|-------|------------|
+| 183 | audit: OWASP Top 10 security review | large |
+| 184 | audit: Authentication and authorization flows | medium |
+| 186 | audit: Secrets, credentials, and configuration security | medium |
+| 187 | audit: Error handling and logging practices | medium |
+| 188 | audit: Code complexity and maintainability | large |
+| 189 | audit: Test coverage and quality | large |
+| 190 | audit: Performance bottlenecks and optimization | large |
+| 191 | audit: API design and consistency | large |
+| 192 | audit: Documentation completeness and quality | large |
+| 193 | audit: Developer experience (DX) review | large |
+| 197 | [Audit] Concurrency and Race Condition Analysis | medium |
+| 198 | [Audit] CI/CD Pipeline Security | medium |
+| 199 | [Audit] Architecture Patterns | large |
+| 201 | [Audit] Error Handling and Recovery | medium |
+| 202 | [Audit] Configuration Management | medium |
+
+---
+
+## By Category
+
+### Security (4 issues)
+
+| # | Title | Priority |
+|---|-------|----------|
+| 221 | Remove StrictHostKeyChecking=no from SSH commands | - |
+| 222 | Sanitize user input in execInContainer to prevent injection | - |
+| 183 | audit: OWASP Top 10 security review | high |
+| 213 | Add logging for security events (authentication, access) | - |
+
+### Testing (3 issues)
+
+| # | Title | Priority |
+|---|-------|----------|
+| 218 | Increase test coverage for low-coverage packages | high |
+| 219 | Add tests for edge cases, error paths, integration | high |
+| 220 | Configure branch coverage measurement in test tooling | - |
+
+### Error Handling (4 issues)
+
+| # | Title |
+|---|-------|
+| 227 | Standardize on cli.Error for user-facing errors, deprecate cli.Fatal |
+| 228 | Implement panic recovery mechanism with graceful shutdown |
+| 229 | Log all errors at handling point with contextual information |
+| 230 | Centralize user-facing error strings in i18n translation files |
+
+### Documentation (6 issues)
+
+| # | Title |
+|---|-------|
+| 231 | Update README.md to reflect actual configuration management |
+| 233 | Add CONTRIBUTING.md with contribution guidelines |
+| 234 | Add CHANGELOG.md to track version changes |
+| 235 | Add user documentation: user guide, FAQ, troubleshooting |
+| 236 | Add configuration documentation to README |
+| 237 | Add Architecture Decision Records (ADRs) |
+
+### Architecture (3 issues)
+
+| # | Title |
+|---|-------|
+| 215 | Refactor Core struct to smaller, focused components |
+| 216 | Introduce typed messaging system for IPC (replace interface{}) |
+| 232 | Create centralized configuration service |
+
+### Performance (2 issues)
+
+| # | Title |
+|---|-------|
+| 224 | Add streaming API to pkg/io/local for large file handling |
+| 225 | Use background goroutines for long-running operations |
+
+### Logging (3 issues)
+
+| # | Title |
+|---|-------|
+| 212 | Implement structured logging (JSON format) |
+| 213 | Add logging for security events |
+| 214 | Implement log retention policy |
+
+### New Features (7 issues)
+
+| # | Title | Priority |
+|---|-------|----------|
+| 168 | feat(crypt): Implement standalone pkg/crypt | high |
+| 167 | feat(config): Implement standalone pkg/config | - |
+| 170 | feat(plugin): Consolidate pkg/module into pkg/plugin | - |
+| 171 | feat(cli): Implement build variants | - |
+| 217 | Implement authentication and authorization features | - |
+| 211 | feat(setup): add .core/setup.yaml for dev environment | - |
+
+### Help System (5 issues)
+
+| # | Title | Complexity |
+|---|-------|------------|
+| 133 | feat(help): Implement display-agnostic help system | large |
+| 134 | feat(help): Remove Wails dependencies from pkg/help | large |
+| 135 | docs(help): Create help content for core CLI | large |
+| 136 | feat(help): Add CLI help command | small |
+| 138 | feat(help): Implement Catalog and Topic types | large |
+| 139 | feat(help): Implement full-text search | small |
+
+---
+
+## Potential Duplicates / Overlaps
+
+1. **Error Handling**: #187, #201, #227-230 all relate to error handling
+2. **Documentation**: #192, #231-237 all relate to documentation
+3. **Configuration**: #202, #167, #232 all relate to configuration
+4. **Security Audits**: #183, #184, #186, #221, #222 all relate to security
+
+---
+
+## Recommendations
+
+1. **Close audit meta-issues as work is done**: Issues #183-202 are meta-audit issues that should be closed once their derived issues are created/completed.
+
+2. **Link related issues**: Create sub-issue relationships:
+   - #187 (audit: error handling) -> #227, #228, #229, #230
+   - #192 (audit: docs) -> #231, #233, #234, #235, #236, #237
+   - #202 (audit: config) -> #167, #232
+
+3. **Good first issues**: #136, #139 are marked as good first issues
+
+4. **Consider closing duplicates**:
+   - #187 vs #201 (both about error handling)
+   - #192 vs #231-237 (documentation)
+
+5. **Priority order for development**:
+   1. Security fixes (#221, #222)
+   2. Test coverage (#218, #219)
+   3. Core infrastructure (#168 - crypt, #167 - config)
+   4. Error handling standardization (#227-230)
+   5. Documentation (#233-237)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,8 +2,8 @@ site_name: Core Framework
 site_url: https://core.help
 site_description: 'A Web3 Framework for building Go desktop applications with Wails v3'
 site_author: 'Snider'
-repo_url: 'https://github.com/Snider/Core'
-repo_name: 'Snider/Core'
+repo_url: 'https://github.com/host-uk/core'
+repo_name: 'host-uk/core'
 
 theme:
   name: material

--- a/pkg/release/config_test.go
+++ b/pkg/release/config_test.go
@@ -304,6 +304,9 @@ func TestConfig_SetProjectDir_Good(t *testing.T) {
 
 func TestWriteConfig_Bad(t *testing.T) {
 	t.Run("returns error for unwritable directory", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root can write to any directory")
+		}
 		dir := t.TempDir()
 
 		// Create .core directory and make it unwritable


### PR DESCRIPTION
## Summary
- Replace manual Go bootstrap with `host-uk/build@dev` action
- Add matrix builds for linux/amd64, linux/arm64, darwin/universal, windows/amd64
- Update README URLs from Snider/Core to host-uk/core
- Simplify artifact handling with `merge-multiple`

## Test plan
- [ ] Merge and verify dev-release workflow runs successfully
- [ ] Tag a release to verify release workflow

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD updated to run a multi-platform build matrix (Linux, macOS, Windows) with a consolidated build step and simplified artifact/release preparation; removed per-platform packaging steps.

* **Documentation**
  * Updated repository references and module/import paths in docs and examples to reflect the new project layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->