### PR TITLE
fix(release): use direct Go build instead of build action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,25 +14,51 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            platform: linux/amd64
+            goos: linux
+            goarch: amd64
+            ext: ""
           - os: ubuntu-latest
-            platform: linux/arm64
+            goos: linux
+            goarch: arm64
+            ext: ""
           - os: macos-latest
-            platform: darwin/universal
+            goos: darwin
+            goarch: amd64
+            ext: ""
+          - os: macos-latest
+            goos: darwin
+            goarch: arm64
+            ext: ""
           - os: windows-latest
-            platform: windows/amd64
+            goos: windows
+            goarch: amd64
+            ext: ".exe"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build
-        uses: host-uk/build@dev
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
-          build-name: core
-          build-platform: ${{ matrix.platform }}
-          build: true
-          package: true
-          sign: false
+          go-version: '1.23'
+          cache: true
+
+      - name: Build CLI
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: |
+          mkdir -p dist
+          go build -ldflags="-s -w -X main.Version=${{ github.ref_name }}" \
+            -o dist/core-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }} \
+            ./cmd/core
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: core-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/core-*
 
   release:
     needs: build


### PR DESCRIPTION
## Summary
- The build action only supports wails2/cpp stacks and defaults to wails2 for unknown projects
- Core is a pure Go CLI with no frontend, so it needs direct `go build`

## Changes
- Replace `host-uk/build@dev` with direct Go build steps
- Build separate darwin/amd64 and darwin/arm64 (instead of darwin/universal which requires lipo)
- Set `CGO_ENABLED=0` for static binaries
- Inject version via `-ldflags -X main.Version=...`

## Context
This unblocks the core CLI release. Once this is merged, we can tag a version and the release workflow will build binaries for all platforms.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the automated build and release process to compile the CLI for multiple platforms with improved artifact organization and distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->