### PR TITLE
fix(release): correct build path to root

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           mkdir -p dist
           go build -ldflags="-s -w -X main.Version=${{ github.ref_name }}" \
             -o dist/core-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }} \
-            ./cmd/core
+            .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Fix the release workflow build path - main.go is at root, not in `./cmd/core`

## Changes
- Changed build path from `./cmd/core` to `.`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration in release workflow to adjust source path resolution during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->