### PR TITLE
fix(release): use bash shell for Windows build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
           cache: true
 
       - name: Build CLI
+        shell: bash
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}


### PR DESCRIPTION
## Summary
PowerShell interprets `.` as dot-sourcing, not as "current directory". Add `shell: bash` to ensure consistent behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build workflow reliability by explicitly configuring shell environment for improved consistency across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->