### PR TITLE
feat(release): package binaries in archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,24 @@ jobs:
         run: |
           mkdir -p dist
           go build -ldflags="-s -w -X main.Version=${{ github.ref_name }}" \
-            -o dist/core-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }} \
+            -o dist/core${{ matrix.ext }} \
             .
+
+      - name: Create archive (Unix)
+        if: matrix.goos != 'windows'
+        shell: bash
+        run: |
+          cd dist
+          tar -czvf core-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz core
+          rm core
+
+      - name: Create archive (Windows)
+        if: matrix.goos == 'windows'
+        shell: bash
+        run: |
+          cd dist
+          zip core-${{ matrix.goos }}-${{ matrix.goarch }}.zip core.exe
+          rm core.exe
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Package release binaries in compressed archives for easier distribution.

## Changes
- Binary built as `core` (or `core.exe`) instead of `core-{os}-{arch}`
- Unix builds: `core-linux-amd64.tar.gz`, `core-darwin-arm64.tar.gz`, etc.
- Windows builds: `core-windows-amd64.zip`

## Why
Prepares for dogfooding - `host-uk/build` can download and extract the core CLI to replace complex GitHub Actions with simple `core build`, `core release` commands.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release artifacts are now delivered as compressed archives for improved distribution efficiency. Unix-based platforms receive tar.gz packages while Windows receives zip packages, replacing the previous raw binary format.
  * Build output naming convention has been simplified for better consistency across all target platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->