### PR TITLE
fix(release): use PowerShell for Windows zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,11 +65,11 @@ jobs:
 
       - name: Create archive (Windows)
         if: matrix.goos == 'windows'
-        shell: bash
+        shell: pwsh
         run: |
           cd dist
-          zip core-${{ matrix.goos }}-${{ matrix.goarch }}.zip core.exe
-          rm core.exe
+          Compress-Archive -Path core.exe -DestinationPath core-${{ matrix.goos }}-${{ matrix.goarch }}.zip
+          Remove-Item core.exe
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Git Bash doesn't have zip. Use PowerShell's Compress-Archive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow configuration to improve Windows archive generation during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->