### PR TITLE
ci(workflows): replace inline pr-gate and auto-merge with org reusable callers

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,37 +4,7 @@ on:
   pull_request:
     types: [opened, reopened, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
-  auto-merge:
-    if: "!github.event.pull_request.draft"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check org membership and enable auto-merge
-        uses: actions/github-script@v7
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const author = context.payload.pull_request.user.login;
-
-            try {
-              await github.rest.orgs.checkMembershipForUser({
-                org: owner,
-                username: author,
-              });
-            } catch {
-              core.info(`${author} is not an org member — skipping auto-merge`);
-              return;
-            }
-
-            await exec.exec('gh', [
-              'pr', 'merge', process.env.PR_NUMBER,
-              '--auto', '--squash',
-            ]);
-            core.info(`Auto-merge enabled for #${process.env.PR_NUMBER}`);
+  merge:
+    uses: host-uk/.github/.github/workflows/auto-merge.yml@dev
+    secrets: inherit

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -4,39 +4,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
 
-permissions:
-  contents: read
-
 jobs:
-  org-gate:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check org membership or approval label
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const author = context.payload.pull_request.user.login;
-
-            // Check if author is an org member
-            try {
-              await github.rest.orgs.checkMembershipForUser({
-                org: owner,
-                username: author,
-              });
-              core.info(`${author} is an org member — gate passed`);
-              return;
-            } catch {
-              core.info(`${author} is not an org member — checking for label`);
-            }
-
-            // Check for external-approved label
-            const labels = context.payload.pull_request.labels.map(l => l.name);
-            if (labels.includes('external-approved')) {
-              core.info('external-approved label present — gate passed');
-              return;
-            }
-
-            core.setFailed(
-              `External PR from ${author} requires an org member to add the "external-approved" label before merge.`
-            );
+  gate:
+    uses: host-uk/.github/.github/workflows/pr-gate.yml@dev
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Moves pr-gate and auto-merge logic to org-wide reusable workflows in `host-uk/.github`
- Fixes org-gate failure: uses `author_association` from webhook payload instead of `checkMembershipForUser` (GITHUB_TOKEN lacks org scope)
- All 18 repos can now adopt the same pr-gate/auto-merge by adding thin callers

## Test plan

- [ ] Verify org-gate passes for org member PRs (was failing for all PRs before)
- [ ] Verify auto-merge enables for org member PRs
- [ ] Verify external PRs are blocked without `external-approved` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)