### PR TITLE
Implement panic recovery and graceful service retrieval

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,7 +4,39 @@ on:
   pull_request:
     types: [opened, reopened, ready_for_review]
 
+permissions:
+  pull-requests: write
+  contents: write
+
 jobs:
   merge:
-    uses: host-uk/.github/.github/workflows/auto-merge.yml@dev
-    secrets: inherit
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: Enable Auto Merge
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const author = context.payload.pull_request.user.login;
+            const association = context.payload.pull_request.author_association;
+
+            // Trusted bot accounts (act as org members)
+            const trustedBots = ['google-labs-jules[bot]'];
+            const isTrustedBot = trustedBots.includes(author);
+
+            // Check author association from webhook payload
+            const trusted = ['MEMBER', 'OWNER', 'COLLABORATOR'];
+            if (!isTrustedBot && !trusted.includes(association)) {
+              core.info(`${author} is ${association} — skipping auto-merge`);
+              return;
+            }
+
+            await exec.exec('gh', [
+              'pr', 'merge', process.env.PR_NUMBER,
+              '--auto',
+              '--repo', `${context.repo.owner}/${context.repo.repo}`
+            ]);
+            core.info(`Auto-merge enabled for #${process.env.PR_NUMBER}`);

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,39 +4,7 @@ on:
   pull_request:
     types: [opened, reopened, ready_for_review]
 
-permissions:
-  pull-requests: write
-  contents: write
-
 jobs:
   merge:
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    steps:
-      - name: Enable Auto Merge
-        uses: actions/github-script@v7
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const author = context.payload.pull_request.user.login;
-            const association = context.payload.pull_request.author_association;
-
-            // Trusted bot accounts (act as org members)
-            const trustedBots = ['google-labs-jules[bot]'];
-            const isTrustedBot = trustedBots.includes(author);
-
-            // Check author association from webhook payload
-            const trusted = ['MEMBER', 'OWNER', 'COLLABORATOR'];
-            if (!isTrustedBot && !trusted.includes(association)) {
-              core.info(`${author} is ${association} — skipping auto-merge`);
-              return;
-            }
-
-            await exec.exec('gh', [
-              'pr', 'merge', process.env.PR_NUMBER,
-              '--auto',
-              '--repo', `${context.repo.owner}/${context.repo.repo}`
-            ]);
-            core.info(`Auto-merge enabled for #${process.env.PR_NUMBER}`);
+    uses: host-uk/.github/.github/workflows/auto-merge.yml@dev
+    secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Run a single test: `go test -run TestName ./...`
 ### Core Framework (`core.go`, `interfaces.go`)
 
 The `Core` struct is the central application container managing:
-- **Services**: Named service registry with type-safe retrieval via `ServiceFor[T]()` and `MustServiceFor[T]()`
+- **Services**: Named service registry with type-safe retrieval via `ServiceFor[T]()`
 - **Actions/IPC**: Message-passing system where services communicate via `ACTION(msg Message)` and register handlers via `RegisterAction()`
 - **Lifecycle**: Services implementing `Startable` (OnStartup) and/or `Stoppable` (OnShutdown) interfaces are automatically called during app lifecycle
 

--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/host-uk/core/pkg/framework"
 	"github.com/host-uk/core/pkg/log"
@@ -20,8 +22,17 @@ var AppVersion = "dev"
 
 // Main initialises and runs the CLI application.
 // This is the main entry point for the CLI.
-// Exits with code 1 on error.
+// Exits with code 1 on error or panic.
 func Main() {
+	// Recovery from panics
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("recovered from panic", "error", r, "stack", string(debug.Stack()))
+			Shutdown()
+			Fatal(fmt.Errorf("panic: %v", r))
+		}
+	}()
+
 	// Initialise CLI runtime with services
 	if err := Init(Options{
 		AppName: AppName,

--- a/pkg/cli/app_test.go
+++ b/pkg/cli/app_test.go
@@ -1,0 +1,164 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"runtime/debug"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPanicRecovery_Good verifies that the panic recovery mechanism
+// catches panics and calls the appropriate shutdown and error handling.
+func TestPanicRecovery_Good(t *testing.T) {
+	t.Run("recovery captures panic value and stack", func(t *testing.T) {
+		var recovered any
+		var capturedStack []byte
+		var shutdownCalled bool
+
+		// Simulate the panic recovery pattern from Main()
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					recovered = r
+					capturedStack = debug.Stack()
+					shutdownCalled = true // simulates Shutdown() call
+				}
+			}()
+
+			panic("test panic")
+		}()
+
+		assert.Equal(t, "test panic", recovered)
+		assert.True(t, shutdownCalled, "Shutdown should be called after panic recovery")
+		assert.NotEmpty(t, capturedStack, "Stack trace should be captured")
+		assert.Contains(t, string(capturedStack), "TestPanicRecovery_Good")
+	})
+
+	t.Run("recovery handles error type panics", func(t *testing.T) {
+		var recovered any
+
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					recovered = r
+				}
+			}()
+
+			panic(fmt.Errorf("error panic"))
+		}()
+
+		err, ok := recovered.(error)
+		assert.True(t, ok, "Recovered value should be an error")
+		assert.Equal(t, "error panic", err.Error())
+	})
+
+	t.Run("recovery handles nil panic gracefully", func(t *testing.T) {
+		recoveryExecuted := false
+
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					recoveryExecuted = true
+				}
+			}()
+
+			// No panic occurs
+		}()
+
+		assert.False(t, recoveryExecuted, "Recovery block should not execute without panic")
+	})
+}
+
+// TestPanicRecovery_Bad tests error conditions in panic recovery.
+func TestPanicRecovery_Bad(t *testing.T) {
+	t.Run("recovery handles concurrent panics", func(t *testing.T) {
+		var wg sync.WaitGroup
+		recoveryCount := 0
+		var mu sync.Mutex
+
+		for i := 0; i < 3; i++ {
+			wg.Add(1)
+			go func(id int) {
+				defer wg.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						mu.Lock()
+						recoveryCount++
+						mu.Unlock()
+					}
+				}()
+
+				panic(fmt.Sprintf("panic from goroutine %d", id))
+			}(i)
+		}
+
+		wg.Wait()
+		assert.Equal(t, 3, recoveryCount, "All goroutine panics should be recovered")
+	})
+}
+
+// TestPanicRecovery_Ugly tests edge cases in panic recovery.
+func TestPanicRecovery_Ugly(t *testing.T) {
+	t.Run("recovery handles typed panic values", func(t *testing.T) {
+		type customError struct {
+			code int
+			msg  string
+		}
+
+		var recovered any
+
+		func() {
+			defer func() {
+				recovered = recover()
+			}()
+
+			panic(customError{code: 500, msg: "internal error"})
+		}()
+
+		ce, ok := recovered.(customError)
+		assert.True(t, ok, "Should recover custom type")
+		assert.Equal(t, 500, ce.code)
+		assert.Equal(t, "internal error", ce.msg)
+	})
+}
+
+// TestMainPanicRecoveryPattern verifies the exact pattern used in Main().
+func TestMainPanicRecoveryPattern(t *testing.T) {
+	t.Run("pattern logs error and calls shutdown", func(t *testing.T) {
+		var logBuffer bytes.Buffer
+		var shutdownCalled bool
+		var fatalErr error
+
+		// Mock implementations
+		mockLogError := func(msg string, args ...any) {
+			fmt.Fprintf(&logBuffer, msg, args...)
+		}
+		mockShutdown := func() {
+			shutdownCalled = true
+		}
+		mockFatal := func(err error) {
+			fatalErr = err
+		}
+
+		// Execute the pattern from Main()
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					mockLogError("recovered from panic: %v", r)
+					mockShutdown()
+					mockFatal(fmt.Errorf("panic: %v", r))
+				}
+			}()
+
+			panic("simulated crash")
+		}()
+
+		assert.Contains(t, logBuffer.String(), "recovered from panic: simulated crash")
+		assert.True(t, shutdownCalled, "Shutdown must be called on panic")
+		assert.NotNil(t, fatalErr, "Fatal must be called with error")
+		assert.Equal(t, "panic: simulated crash", fatalErr.Error())
+	})
+}

--- a/pkg/cli/runtime.go
+++ b/pkg/cli/runtime.go
@@ -147,9 +147,9 @@ func Shutdown() {
 // --- Signal Service (internal) ---
 
 type signalService struct {
-	cancel     context.CancelFunc
-	sigChan    chan os.Signal
-	onReload   func() error
+	cancel       context.CancelFunc
+	sigChan      chan os.Signal
+	onReload     func() error
 	shutdownOnce sync.Once
 }
 

--- a/pkg/cli/runtime.go
+++ b/pkg/cli/runtime.go
@@ -147,9 +147,10 @@ func Shutdown() {
 // --- Signal Service (internal) ---
 
 type signalService struct {
-	cancel   context.CancelFunc
-	sigChan  chan os.Signal
-	onReload func() error
+	cancel     context.CancelFunc
+	sigChan    chan os.Signal
+	onReload   func() error
+	shutdownOnce sync.Once
 }
 
 // SignalOption configures signal handling.
@@ -209,7 +210,9 @@ func (s *signalService) OnStartup(ctx context.Context) error {
 }
 
 func (s *signalService) OnShutdown(ctx context.Context) error {
-	signal.Stop(s.sigChan)
-	close(s.sigChan)
+	s.shutdownOnce.Do(func() {
+		signal.Stop(s.sigChan)
+		close(s.sigChan)
+	})
 	return nil
 }

--- a/pkg/framework/core/core.go
+++ b/pkg/framework/core/core.go
@@ -241,13 +241,9 @@ func ServiceFor[T any](c *Core, name string) (T, error) {
 }
 
 // MustServiceFor retrieves a registered service by name and asserts its type to the given interface T.
-// It panics if the service is not found or cannot be cast to T.
-func MustServiceFor[T any](c *Core, name string) T {
-	svc, err := ServiceFor[T](c, name)
-	if err != nil {
-		panic(err)
-	}
-	return svc
+// It returns an error if the service is not found or cannot be cast to T.
+func MustServiceFor[T any](c *Core, name string) (T, error) {
+	return ServiceFor[T](c, name)
 }
 
 // App returns the global application instance.
@@ -289,15 +285,13 @@ func ClearInstance() {
 }
 
 // Config returns the registered Config service.
-func (c *Core) Config() Config {
-	cfg := MustServiceFor[Config](c, "config")
-	return cfg
+func (c *Core) Config() (Config, error) {
+	return MustServiceFor[Config](c, "config")
 }
 
 // Display returns the registered Display service.
-func (c *Core) Display() Display {
-	d := MustServiceFor[Display](c, "display")
-	return d
+func (c *Core) Display() (Display, error) {
+	return MustServiceFor[Display](c, "display")
 }
 
 // Core returns self, implementing the CoreProvider interface.

--- a/pkg/framework/core/core.go
+++ b/pkg/framework/core/core.go
@@ -240,8 +240,10 @@ func ServiceFor[T any](c *Core, name string) (T, error) {
 	return typed, nil
 }
 
-// MustServiceFor retrieves a registered service by name and asserts its type to the given interface T.
-// It returns an error if the service is not found or cannot be cast to T.
+// MustServiceFor retrieves a typed service or returns an error if not found.
+//
+// Deprecated: use ServiceFor instead. This function does not panic on failure
+// and is retained only for backward compatibility.
 func MustServiceFor[T any](c *Core, name string) (T, error) {
 	return ServiceFor[T](c, name)
 }

--- a/pkg/framework/core/core_test.go
+++ b/pkg/framework/core/core_test.go
@@ -68,20 +68,24 @@ func TestCore_Services_Good(t *testing.T) {
 	err = c.RegisterService("display", &MockDisplayService{})
 	assert.NoError(t, err)
 
-	assert.NotNil(t, c.Config())
-	assert.NotNil(t, c.Display())
+	cfg, err := c.Config()
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg)
+
+	d, err := c.Display()
+	assert.NoError(t, err)
+	assert.NotNil(t, d)
 }
 
 func TestCore_Services_Ugly(t *testing.T) {
 	c, err := New()
 	assert.NoError(t, err)
 
-	assert.Panics(t, func() {
-		c.Config()
-	})
-	assert.Panics(t, func() {
-		c.Display()
-	})
+	_, err = c.Config()
+	assert.Error(t, err)
+
+	_, err = c.Display()
+	assert.Error(t, err)
 }
 
 func TestCore_App_Good(t *testing.T) {
@@ -224,21 +228,21 @@ func TestCore_MustServiceFor_Good(t *testing.T) {
 	assert.NoError(t, err)
 	err = c.RegisterService("test", &MockService{Name: "test"})
 	assert.NoError(t, err)
-	svc := MustServiceFor[*MockService](c, "test")
+	svc, err := MustServiceFor[*MockService](c, "test")
+	assert.NoError(t, err)
 	assert.Equal(t, "test", svc.GetName())
 }
 
 func TestCore_MustServiceFor_Ugly(t *testing.T) {
 	c, err := New()
 	assert.NoError(t, err)
-	assert.Panics(t, func() {
-		MustServiceFor[*MockService](c, "nonexistent")
-	})
+	_, err = MustServiceFor[*MockService](c, "nonexistent")
+	assert.Error(t, err)
+
 	err = c.RegisterService("test", "not a service")
 	assert.NoError(t, err)
-	assert.Panics(t, func() {
-		MustServiceFor[*MockService](c, "test")
-	})
+	_, err = MustServiceFor[*MockService](c, "test")
+	assert.Error(t, err)
 }
 
 type MockAction struct {

--- a/pkg/framework/core/runtime_pkg.go
+++ b/pkg/framework/core/runtime_pkg.go
@@ -34,7 +34,7 @@ func (r *ServiceRuntime[T]) Opts() T {
 
 // Config returns the registered Config service from the core application.
 // This is a convenience method for accessing the application's configuration.
-func (r *ServiceRuntime[T]) Config() Config {
+func (r *ServiceRuntime[T]) Config() (Config, error) {
 	return r.core.Config()
 }
 

--- a/pkg/framework/core/runtime_pkg_test.go
+++ b/pkg/framework/core/runtime_pkg_test.go
@@ -121,8 +121,7 @@ func TestNewServiceRuntime_Good(t *testing.T) {
 	assert.Equal(t, c, sr.Core())
 
 	// We can't directly test sr.Config() without a registered config service,
-	// but we can ensure it doesn't panic. We'll test the panic case separately.
-	assert.Panics(t, func() {
-		sr.Config()
-	})
+	// but we can ensure it returns an error.
+	_, err = sr.Config()
+	assert.Error(t, err)
 }

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -61,6 +61,9 @@ func ServiceFor[T any](c *Core, name string) (T, error) {
 }
 
 // MustServiceFor retrieves a typed service or returns an error if not found.
+//
+// Deprecated: use ServiceFor instead. This function does not panic on failure
+// and is retained only for backward compatibility.
 func MustServiceFor[T any](c *Core, name string) (T, error) {
 	return core.MustServiceFor[T](c, name)
 }

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -60,8 +60,8 @@ func ServiceFor[T any](c *Core, name string) (T, error) {
 	return core.ServiceFor[T](c, name)
 }
 
-// MustServiceFor retrieves a typed service or panics if not found.
-func MustServiceFor[T any](c *Core, name string) T {
+// MustServiceFor retrieves a typed service or returns an error if not found.
+func MustServiceFor[T any](c *Core, name string) (T, error) {
 	return core.MustServiceFor[T](c, name)
 }
 

--- a/pkg/io/local/client.go
+++ b/pkg/io/local/client.go
@@ -48,7 +48,6 @@ func (m *Medium) path(p string) string {
 		return clean
 	}
 
-
 	// Join cleaned relative path with root
 	return filepath.Join(m.root, clean)
 }

--- a/pkg/process/types.go
+++ b/pkg/process/types.go
@@ -11,7 +11,7 @@
 //	)
 //
 //	// Get service and run a process
-//	svc := framework.MustServiceFor[*process.Service](core, "process")
+//	svc, _ := framework.MustServiceFor[*process.Service](core, "process")
 //	proc, _ := svc.Start(ctx, "go", "test", "./...")
 //
 // # Listening for Events

--- a/pkg/process/types.go
+++ b/pkg/process/types.go
@@ -11,8 +11,11 @@
 //	)
 //
 //	// Get service and run a process
-//	svc, _ := framework.MustServiceFor[*process.Service](core, "process")
-//	proc, _ := svc.Start(ctx, "go", "test", "./...")
+//	svc, err := framework.ServiceFor[*process.Service](core, "process")
+//	if err != nil {
+//	    return err
+//	}
+//	proc, err := svc.Start(ctx, "go", "test", "./...")
 //
 // # Listening for Events
 //


### PR DESCRIPTION
Implemented a robust panic recovery mechanism in the CLI's main entry point to ensure that any unexpected panics are caught, logged with stack traces, and trigger a graceful shutdown before the application exits. 

Additionally, refactored the core service retrieval logic. Specifically, `MustServiceFor`, `Config()`, and `Display()` now return errors instead of panicking when a service is not found or has an incorrect type. This allows callers to handle these situations more gracefully. 

To support the new recovery flow, the `signalService`'s shutdown logic was made idempotent using `sync.Once`, preventing 'close of closed channel' panics if `Shutdown()` is called multiple times (e.g., once by a signal and again by the panic recovery block).

All tests in `pkg/framework/core` and `pkg/cli` have been updated and verified to pass. A full repository build (`go build ./...`) was successful, confirming no regressions or compilation errors were introduced.

Fixes #228

---
*PR created automatically by Jules for task [12978196133066173696](https://jules.google.com/task/12978196133066173696) started by @Snider*