### PR TITLE
fix(ci): gofmt base branch + auto-merge permissions

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, reopened, ready_for_review]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   merge:
     uses: host-uk/.github/.github/workflows/auto-merge.yml@dev

--- a/pkg/io/local/client.go
+++ b/pkg/io/local/client.go
@@ -48,7 +48,6 @@ func (m *Medium) path(p string) string {
 		return clean
 	}
 
-
 	// Join cleaned relative path with root
 	return filepath.Join(m.root, clean)
 }


### PR DESCRIPTION
## Summary
- Remove extra blank line in `pkg/io/local/client.go` that causes the QA `fmt` check to fail on all PRs
- Add missing `permissions` block to auto-merge workflow caller (was causing `startup_failure` on every run)
- Org reusable workflow also fixed: removed `--squash` flag that conflicts with merge queue

**Impact:** Unblocks all 13 Jules PRs (#304-#316) that were failing QA due to base branch formatting, and fixes auto-merge for all future PRs.

## Test plan
- [ ] QA fmt check passes on this PR
- [ ] Auto-merge workflow no longer gets startup_failure
- [ ] After merge, Jules PRs pass QA and auto-merge kicks in

🤖 Generated with [Claude Code](https://claude.com/claude-code)