### PR TITLE
fix(ci): configure git auth for homebrew-tap push

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -171,8 +171,11 @@ jobs:
           LINUX_AMD64=$(cat dist/core-linux-amd64.tar.gz.sha256)
           LINUX_ARM64=$(cat dist/core-linux-arm64.tar.gz.sha256)
 
-          # Clone tap repo
+          # Clone tap repo (configure auth for push)
           gh repo clone host-uk/homebrew-tap /tmp/tap -- --depth=1
+          cd /tmp/tap
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/host-uk/homebrew-tap.git"
+          cd -
           mkdir -p /tmp/tap/Formula
 
           # Write formula


### PR DESCRIPTION
## Summary
- Set remote URL with `x-access-token` auth after cloning `homebrew-tap` so `git push` can authenticate using `HOMEBREW_TAP_TOKEN`
- Fixes the `update-tap` job failure from alpha.20 where push failed with "could not read Username"

## Test plan
- [ ] Next alpha release should have `update-tap` succeed
- [ ] `host-uk/homebrew-tap` Formula/core.rb updated with real checksums

🤖 Generated with [Claude Code](https://claude.com/claude-code)